### PR TITLE
Develop

### DIFF
--- a/src/main/java/es/ucm/fdi/physionet/controller/PatientController.java
+++ b/src/main/java/es/ucm/fdi/physionet/controller/PatientController.java
@@ -109,8 +109,11 @@ public class PatientController {
         Appointment app = new Appointment();
         User sessionUser = utils.getFreshSessionUser();
 
-        List users = entityManager.createNamedQuery(Queries.GET_USER_BY_USERNAME).setParameter("username", doctor).getResultList();
-        User doctorUser = (User) users.get(0);
+        List<User> users = entityManager
+            .createNamedQuery(Queries.GET_USER_BY_USERNAME, User.class)
+            .setParameter("username", doctor)
+            .getResultList();
+        User doctorUser = users.get(0);
         LocalDate dateLocal = LocalDate.parse(date);
         ZonedDateTime date2 = ZonedDateTime.parse(date + "T" + hour + ":00+02:00[Europe/Madrid]");
 
@@ -151,7 +154,10 @@ public class PatientController {
         User u = utils.getFreshSessionUser();
         utils.setDefaultModelAttributes(model, UserRole.PATIENT);
 
-        List doctorsList = entityManager.createNamedQuery(Queries.GET_USER_BY_ROLE).setParameter("role", "DOCTOR").getResultList();
+        List<User> doctorsList = entityManager
+            .createNamedQuery(Queries.GET_USER_BY_ROLE, User.class)
+            .setParameter("role", "DOCTOR")
+            .getResultList();
 
         model.addAttribute("today", false);
         model.addAttribute("appointments", getAppointmentsPending(u));

--- a/src/test/java/karate-config.js
+++ b/src/test/java/karate-config.js
@@ -1,7 +1,13 @@
 function fn() {
 
+    var driverConfigs = {
+        'chromium-linux':{ type: 'chrome', executable: '/usr/bin/chromium-browser', showDriverLog: true },
+        'chrome-windows':{ type: 'chrome', showDriverLog: true }
+    }
+
     var config = {
-        baseUrl : 'http://localhost:8080'
+        baseUrl : 'http://localhost:8080',
+        driverConfig: driverConfigs['chromium-linux']
     };
 
     return config;

--- a/src/test/java/karate/controller/admincontroller.feature
+++ b/src/test/java/karate/controller/admincontroller.feature
@@ -2,10 +2,10 @@ Feature: AdminController tests
 
 Background:
 # chromium bajo linux; si usas google-chrome, puedes quitar executable (que es lo que usaría por defecto)
-  * configure driver = { type: 'chrome', showDriverLog: true }
+  * configure driver = driverConfig
 
 Scenario: Admin can see patients correctly
-  Given driver 'http://localhost:8080/login'
+  Given driver baseUrl+'/login'
   And input('#username', 'admin')
   And input('#password', 'aa')
   When submit().click("button[type=submit]")
@@ -13,7 +13,7 @@ Scenario: Admin can see patients correctly
   And match html('body') contains 'Arturo Martínez'
 
 Scenario: Admin can see doctors correctly
-  Given driver 'http://localhost:8080/login'
+  Given driver baseUrl+'/login'
   And input('#username', 'admin')
   And input('#password', 'aa')
   When submit().click("button[type=submit]")
@@ -22,7 +22,7 @@ Scenario: Admin can see doctors correctly
   And match html('body') contains 'Fernando Martínez'
 
 Scenario: Admin can see absences correctly
-  Given driver 'http://localhost:8080/login'
+  Given driver baseUrl+'/login'
   And input('#username', 'admin')
   And input('#password', 'aa')
   When submit().click("button[type=submit]")

--- a/src/test/java/karate/controller/doctorcontroller.feature
+++ b/src/test/java/karate/controller/doctorcontroller.feature
@@ -1,11 +1,10 @@
 Feature: DoctorController tests
 
 Background:
-  # chromium bajo linux; si usas google-chrome, puedes quitar executable (que es lo que usaría por defecto)
-    * configure driver = { type: 'chrome', showDriverLog: true }
+  * configure driver = driverConfig
 
 Scenario: Doctor typical app interaction
-  Given driver 'http://localhost:8080/login'
+  Given driver baseUrl+'/login'
   And input('#username', 'doctor')
   And input('#password', 'aa')
 

--- a/src/test/java/karate/controller/patientcontroller.feature
+++ b/src/test/java/karate/controller/patientcontroller.feature
@@ -1,13 +1,10 @@
 Feature: PatientController tests
 
   Background:
-  # chromium bajo linux; si usas google-chrome, puedes quitar executable (que es lo que usaría por defecto)
-    * configure driver = { type: 'chrome', showDriverLog: true }
-    * url baseUrl
-    * def util = Java.type('karate.KarateTests')
+    * configure driver = driverConfig
 
   Scenario: Patient typical app interaction
-    Given driver 'http://localhost:8080/login'
+    Given driver baseUrl+'/login'
     And input('#username', 'patient')
     And input('#password', 'aa')
 


### PR DESCRIPTION
* En algunas consultas, veo 

~~~{.java}
    List users = entityManager.createNamedQuery(Queries.GET_USER_BY_USERNAME).setParameter("username", doctor).getResultList();
~~~

Esto es feo, porque usa listas sin tipo. Es más elegante hacer ésto (incluyo algún ejemplo en el PR):

~~~{.java}
    List<User> users = entityManager
        .createNamedQuery(Queries.GET_USER_BY_USERNAME, User.class)
        .setParameter("username", doctor)
        .getResultList();
~~~

* Enhorabuena, vuestros tests funcionan. Podeis hacer que sean algo más fáciles de usar desde otro SSOO aplicando este PR, ya que ahora repetís muchas veces la configuración exacta de driver a usar (en los tests externos) -- e idealmente la configuración sólo debería aparecer 1 vez. He movido la parte común a karate-config.js, y ahora deberían funcionar en windows ó linux cambiando sólo 1 línea en este fichero. Ya puestos también he sacado factor común de la URL.

* En muchos puntos, filtrais con `.stream().filter(...).collect(...)`. Esto funciona, pero lo suyo sería filtrar a nivel de consulta en la BD (por ejemplo, si estás filtrando por fecha, usarías una cláusula `WHERE a.date BETWEEN :start AND :end`). Este cambio hace que el código sea algo más elegante/eficiente, pero no es urgente.

* En la pantalla mensajes, siempre aparece 0 junto a los nombres de interlocutores, aunque haya mensajes sin leer.

* No puedo ver historial de pacientes, o tomar notas de lo que les pasa, o ver citas del pasado. Echo en falta algo más de funcionalidad principal de la aplicación, aunque lo que hay funciona bastante bien.